### PR TITLE
Build 3 — Gate 1 cleanup: summarise.yml + UNIQUE(source_id)

### DIFF
--- a/.github/workflows/summarise.yml
+++ b/.github/workflows/summarise.yml
@@ -1,19 +1,16 @@
-name: NewsMirror summarise
+name: NewsMirror summarise (manual-only)
 
 on:
-  schedule:
-    # Summarise pending articles every 3 hours
-    - cron: '0 */3 * * *'
   workflow_dispatch:
 
 jobs:
   summarise:
     runs-on: ubuntu-latest
     steps:
-      - name: Summarise pending articles
+      - name: Summarise pending articles (manual trigger)
         run: |
           curl -s -X POST \
-            "${{ secrets.SUPABASE_URL }}/functions/v1/ingest-articles?phase=summarise" \
-           -H "Authorization: Bearer ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" \
+            "${{ secrets.SUPABASE_URL }}/functions/v1/ingest-articles" \
+            -H "Authorization: Bearer ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" \
             -H "Content-Type: application/json" \
             --data '{}'

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -67,6 +67,7 @@ create table user_preferences (
 create table source_ideology_scores (
   id                    uuid primary key default gen_random_uuid(),
   source_id             uuid not null references sources(id) on delete cascade,
+  constraint source_ideology_scores_source_id_unique unique (source_id),
   scored_at             timestamptz not null default now(),
   identity_score        float not null,
   state_trust_score     float not null,


### PR DESCRIPTION
## Summary
Gate 1 cleanup for Build 3:

1. **Supabase DB migration** — added `UNIQUE (source_id)` constraint on `source_ideology_scores`.
   - Applied via Supabase migration `add_unique_source_ideology_scores_source_id`.
   - Keeps aggregation `ON CONFLICT (source_id)` upserts safe for classifier profiles.

2. **summarise.yml workflow** — disable redundant scheduled full-pipeline run.
   - Changed to **manual-only** workflow (`workflow_dispatch` only).
   - Updated to call the Edge Function without the unused `?phase=summarise` param for clarity.

## Files Changed
- `.github/workflows/summarise.yml`
  - Removed 3-hour cron schedule
  - Now manual-only, still calls the ingest Edge Function

- `supabase/schema.sql`
  - Documented `constraint source_ideology_scores_source_id_unique unique (source_id)` on `source_ideology_scores`
  - Matches the live DB schema after the applied migration

## Related Issues
- Closes #4 (fix summarise.yml redundant run)
- Closes #5 (UNIQUE constraint for source_ideology_scores.source_id)

## Notes
This PR does **not** yet:
- Add `?phase=` routing in the Edge Function
- Implement classifier or aggregation logic

Those are covered in Gate 2 issues (#8–#11).