### PR TITLE
Build 3 — Gate 2: classifier phase, schedule, and aggregation

### DIFF
--- a/.github/workflows/classify.yml
+++ b/.github/workflows/classify.yml
@@ -1,0 +1,16 @@
+name: NewsMirror classify
+on:
+  schedule:
+    - cron: '0 */2 * * *'   # every 2 hours
+  workflow_dispatch:
+jobs:
+  classify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Classify pending articles
+        run: |
+          curl -s -X POST \
+            "${{ secrets.SUPABASE_URL }}/functions/v1/ingest-articles?phase=classify" \
+            -H "Authorization: Bearer ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" \
+            -H "Content-Type: application/json" \
+            --data '{}'

--- a/docs/classifier-prompt-and-validation.txt
+++ b/docs/classifier-prompt-and-validation.txt
@@ -1,0 +1,98 @@
+NewsMirror Classifier Prompt & Validation Notes
+==============================================
+
+This file tracks the **canonical Gemini classification prompt** and manual validation runs.
+
+Prompt (Build 3 Canonical)
+--------------------------
+
+You are classifying an Indian news article across four editorial stance axes. 
+This is NOT about the events reported, but about HOW the outlet frames them.
+
+Score each axis from 0.0 to 1.0. Scores should be granular (e.g. 0.3, 0.65, 0.8) — avoid clustering at 0.5.
+If the article is genuinely neutral on an axis, use 0.5. Reserve 0.5 only for true neutrality.
+
+AXES:
+
+1. identity_score
+   0.0 = Frames all groups with equal weight, avoids majoritarian assumptions, uses neutral/plural language
+   1.0 = Frames issues primarily through a majority-community lens, minority groups treated as "other" or secondary
+   Example 0.2: Article on communal tension uses equal quotes from both communities, avoids loaded terms
+   Example 0.8: Same event described with language that implicitly centres Hindu nationalist framing
+
+2. state_trust_score
+   0.0 = Treats government claims with editorial scepticism, seeks independent verification, highlights opposition views
+   1.0 = Reproduces government statements as fact without challenge, minimal opposition or expert counter-voice
+   Example 0.1: Article on GDP growth questions methodology, cites independent economists
+   Example 0.9: Article on GDP growth reprints ministry press release with no additional voices
+
+3. economic_score
+   0.0 = Centres welfare impact, redistribution, labour rights, or inequality in framing economic stories
+   1.0 = Centres GDP growth, investor confidence, ease of doing business, market efficiency
+   Example 0.2: Coverage of a factory closure focuses on workers displaced, community impact
+   Example 0.8: Same story focuses on impact to sector FDI and government ease-of-business ranking
+
+4. institution_score
+   0.0 = Critical or questioning stance toward courts, RBI, Election Commission, press institutions
+   1.0 = Deferential toward institutional decisions, treats institutional authority as legitimate and final
+   Example 0.2: Article on Supreme Court verdict notes criticism from legal scholars
+   Example 0.9: Article on same verdict treats it as settled and authoritative, no critical voices
+
+IMPORTANT:
+- Score the framing and editorial choices, NOT the facts reported
+- Many articles will be genuinely neutral on some axes — 0.5 is valid when warranted
+- Short or purely factual articles with no evident framing should return null for all scores
+- Return ONLY valid JSON, no explanation, no markdown
+
+Headline: {{headline}}
+Summary: {{summary}}
+Body (first 1500 chars): {{body}}
+
+Return this JSON and nothing else:
+{
+  "identity_score": 0.0,
+  "state_trust_score": 0.0,
+  "economic_score": 0.0,
+  "institution_score": 0.0,
+  "rationale": {
+    "identity": "one sentence",
+    "state_trust": "one sentence",
+    "economic": "one sentence",
+    "institution": "one sentence"
+  },
+  "unclassifiable": false
+}
+
+If the article is too short, purely factual, sports, or entertainment with no political framing,
+set "unclassifiable": true and all scores to null.
+
+Manual Validation Runs (to be filled by Shubham)
+------------------------------------------------
+
+Use this section to paste representative classifier outputs from Gemini for 20–30 articles.
+
+For each sample, record:
+- Source (e.g. The Hindu, TOI, Mint, NDTV, Scroll, OpIndia)
+- URL or article ID
+- Raw JSON response from Gemini
+- Any observations about whether the scores "feel" right
+
+Example template (fill in manually):
+
+1. Source: The Hindu
+   Article ID: ...
+   JSON:
+   {
+     "identity_score": ...,
+     "state_trust_score": ...,
+     "economic_score": ...,
+     "institution_score": ...,
+     "rationale": {...},
+     "unclassifiable": false
+   }
+   Notes: ...
+
+2. Source: OpIndia
+   Article ID: ...
+   JSON: {...}
+   Notes: ...

--- a/supabase/functions/ingest-articles/index.ts
+++ b/supabase/functions/ingest-articles/index.ts
@@ -276,9 +276,143 @@ Summary: ${summary}`;
   }
 }
 
-// ─── MAIN HANDLER ─────────────────────────────────────────────────────────────
+// ─── CLASSIFICATION (BUILD 3) ─────────────────────────────────────────────────
 
-Deno.serve(async (_req) => {
+interface ClassifierOutput {
+  identity_score: number | null;
+  state_trust_score: number | null;
+  economic_score: number | null;
+  institution_score: number | null;
+  rationale: {
+    identity: string;
+    state_trust: string;
+    economic: string;
+    institution: string;
+  };
+  unclassifiable: boolean;
+}
+
+const CLASSIFIER_PROMPT_TEMPLATE = `You are classifying an Indian news article across four editorial stance axes. 
+This is NOT about the events reported, but about HOW the outlet frames them.
+
+Score each axis from 0.0 to 1.0. Scores should be granular (e.g. 0.3, 0.65, 0.8) — avoid clustering at 0.5.
+If the article is genuinely neutral on an axis, use 0.5. Reserve 0.5 only for true neutrality.
+
+AXES:
+
+1. identity_score
+   0.0 = Frames all groups with equal weight, avoids majoritarian assumptions, uses neutral/plural language
+   1.0 = Frames issues primarily through a majority-community lens, minority groups treated as "other" or secondary
+   Example 0.2: Article on communal tension uses equal quotes from both communities, avoids loaded terms
+   Example 0.8: Same event described with language that implicitly centres Hindu nationalist framing
+
+2. state_trust_score
+   0.0 = Treats government claims with editorial scepticism, seeks independent verification, highlights opposition views
+   1.0 = Reproduces government statements as fact without challenge, minimal opposition or expert counter-voice
+   Example 0.1: Article on GDP growth questions methodology, cites independent economists
+   Example 0.9: Article on GDP growth reprints ministry press release with no additional voices
+
+3. economic_score
+   0.0 = Centres welfare impact, redistribution, labour rights, or inequality in framing economic stories
+   1.0 = Centres GDP growth, investor confidence, ease of doing business, market efficiency
+   Example 0.2: Coverage of a factory closure focuses on workers displaced, community impact
+   Example 0.8: Same story focuses on impact to sector FDI and government ease-of-business ranking
+
+4. institution_score
+   0.0 = Critical or questioning stance toward courts, RBI, Election Commission, press institutions
+   1.0 = Deferential toward institutional decisions, treats institutional authority as legitimate and final
+   Example 0.2: Article on Supreme Court verdict notes criticism from legal scholars
+   Example 0.9: Article on same verdict treats it as settled and authoritative, no critical voices
+
+IMPORTANT:
+- Score the framing and editorial choices, NOT the facts reported
+- Many articles will be genuinely neutral on some axes — 0.5 is valid when warranted
+- Short or purely factual articles with no evident framing should return null for all scores
+- Return ONLY valid JSON, no explanation, no markdown
+
+Headline: {{headline}}
+Summary: {{summary}}
+Body (first 1500 chars): {{body}}
+
+Return this JSON and nothing else:
+{
+  "identity_score": 0.0,
+  "state_trust_score": 0.0,
+  "economic_score": 0.0,
+  "institution_score": 0.0,
+  "rationale": {
+    "identity": "one sentence",
+    "state_trust": "one sentence",
+    "economic": "one sentence",
+    "institution": "one sentence"
+  },
+  "unclassifiable": false
+}
+
+If the article is too short, purely factual, sports, or entertainment with no political framing,
+set "unclassifiable": true and all scores to null.`;
+
+async function classifyArticle(
+  headline: string,
+  summary: string,
+  body: string
+): Promise<ClassifierOutput> {
+  const prompt = CLASSIFIER_PROMPT_TEMPLATE
+    .replace("{{headline}}", headline)
+    .replace("{{summary}}", summary)
+    .replace("{{body}}", body.slice(0, 1500));
+
+  const res = await fetch(`${GEMINI_URL}?key=${GEMINI_API_KEY}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      contents: [{ parts: [{ text: prompt }] }],
+      generationConfig: { temperature: 0, maxOutputTokens: 400 },
+    }),
+  });
+
+  if (!res.ok) {
+    const err = await res.text();
+    throw new Error(`Gemini classify error: ${err}`);
+  }
+
+  const data = await res.json();
+  const raw = data.candidates?.[0]?.content?.parts?.[0]?.text?.trim() ?? "";
+
+  if (!raw) {
+    throw new Error("Empty classifier response");
+  }
+
+  let parsed: any;
+  try {
+    const cleaned = raw.replace(/```json|```/g, "").trim();
+    parsed = JSON.parse(cleaned);
+  } catch (e) {
+    throw new Error(`Failed to parse classifier JSON: ${(e as Error).message}`);
+  }
+
+  const unclassifiable = parsed.unclassifiable === true;
+
+  const output: ClassifierOutput = {
+    identity_score: unclassifiable ? null : parsed.identity_score ?? null,
+    state_trust_score: unclassifiable ? null : parsed.state_trust_score ?? null,
+    economic_score: unclassifiable ? null : parsed.economic_score ?? null,
+    institution_score: unclassifiable ? null : parsed.institution_score ?? null,
+    rationale: {
+      identity: parsed.rationale?.identity ?? "",
+      state_trust: parsed.rationale?.state_trust ?? "",
+      economic: parsed.rationale?.economic ?? "",
+      institution: parsed.rationale?.institution ?? "",
+    },
+    unclassifiable,
+  };
+
+  return output;
+}
+
+// ─── HANDLERS ────────────────────────────────────────────────────────────────
+
+async function handleIngest(): Promise<Response> {
   const results = { processed: 0, inserted: 0, skipped: 0, errors: 0 };
   const now = new Date();
 
@@ -313,7 +447,7 @@ Deno.serve(async (_req) => {
             .from("articles")
             .select("id")
             .eq("url", item.url)
-            .single();
+            .maybeSingle();
 
           if (existing) {
             results.skipped++;
@@ -329,7 +463,7 @@ Deno.serve(async (_req) => {
               summary = await summariseArticle(
                 item.headline,
                 item.body,
-                source.language
+                (source as any).language ?? "en"
               );
               if (summary) {
                 topic_tags = await tagTopics(item.headline, summary);
@@ -349,7 +483,7 @@ Deno.serve(async (_req) => {
           }
 
           const { error: insertErr } = await supabase.from("articles").insert({
-            source_id: source.id,
+            source_id: (source as any).id,
             url: item.url,
             headline: item.headline,
             body: item.body.slice(0, 8000), // cap stored body
@@ -361,7 +495,7 @@ Deno.serve(async (_req) => {
 
           if (insertErr) {
             // Unique constraint violation = already exists, safe to skip
-            if (insertErr.code === "23505") {
+            if ((insertErr as any).code === "23505") {
               results.skipped++;
             } else {
               console.error("Insert error:", insertErr);
@@ -375,7 +509,7 @@ Deno.serve(async (_req) => {
           await new Promise((r) => setTimeout(r, 300));
         }
       } catch (sourceErr) {
-        console.error(`Error processing source ${source.name}:`, sourceErr);
+        console.error(`Error processing source ${ (source as any).name }:", sourceErr);
         results.errors++;
       }
     }
@@ -386,4 +520,99 @@ Deno.serve(async (_req) => {
 
   console.log("Ingest complete:", results);
   return Response.json({ results, timestamp: new Date().toISOString() });
+}
+
+async function handleClassify(): Promise<Response> {
+  const batchSize = 30;
+  const now = new Date();
+
+  const summary: any = {
+    requested: batchSize,
+    processed: 0,
+    classified: 0,
+    unclassifiable: 0,
+    errors: 0,
+  };
+
+  try {
+    const { data: articles, error } = await supabase
+      .from("articles")
+      .select("id, source_id, headline, summary, body, published_at")
+      .is("identity_score", null)
+      .not("summary", "is", null)
+      .neq("summary", "")
+      .order("ingested_at", { ascending: true })
+      .limit(batchSize);
+
+    if (error) throw error;
+    if (!articles || articles.length === 0) {
+      return Response.json({
+        message: "No articles pending classification",
+        summary,
+      });
+    }
+
+    for (const article of articles) {
+      summary.processed++;
+      try {
+        const output = await classifyArticle(
+          (article as any).headline,
+          (article as any).summary,
+          (article as any).body ?? ""
+        );
+
+        const { error: updateErr } = await supabase
+          .from("articles")
+          .update({
+            identity_score: output.identity_score,
+            state_trust_score: output.state_trust_score,
+            economic_score: output.economic_score,
+            institution_score: output.institution_score,
+            classifier_rationale: output,
+          })
+          .eq("id", (article as any).id);
+
+        if (updateErr) {
+          console.error("Update error:", updateErr);
+          summary.errors++;
+        } else {
+          if (output.unclassifiable) {
+            summary.unclassifiable++;
+          } else {
+            summary.classified++;
+          }
+        }
+      } catch (e) {
+        console.error("Classification error:", e);
+        summary.errors++;
+      }
+
+      // Slight delay to avoid hammering Gemini
+      await new Promise((r) => setTimeout(r, 500));
+    }
+
+    // Refresh source_ideology_scores aggregation
+    try {
+      await supabase.rpc("refresh_source_ideology_scores");
+    } catch (aggErr) {
+      console.error("Aggregation error:", aggErr);
+    }
+  } catch (err) {
+    console.error("Fatal classify error:", err);
+    return Response.json({ error: String(err) }, { status: 500, summary });
+  }
+
+  return Response.json({ summary, timestamp: now.toISOString() });
+}
+
+// ─── ROUTER ───────────────────────────────────────────────────────────────────
+
+Deno.serve(async (req) => {
+  const url = new URL(req.url);
+  const phase = url.searchParams.get("phase") ?? "ingest";
+
+  if (phase === "ingest") return handleIngest();
+  if (phase === "classify") return handleClassify();
+
+  return Response.json({ error: "Unknown phase" }, { status: 400 });
 });


### PR DESCRIPTION
## Summary
Build 3 Gate 2 implementation: classifier backend, scheduled phase, and prompt notes.

This PR introduces a **dark-launched classifier pipeline** while keeping ingest behaviour unchanged.

---

## 1. Edge Function refactor — phase routing

`supabase/functions/ingest-articles/index.ts`

- Extracted the existing ingest logic into `async function handleIngest(): Promise<Response>` with **no behavioural changes**.
- Added a new `async function handleClassify(): Promise<Response>` for ideology classification.
- Introduced a simple router:

```ts
Deno.serve(async (req) => {
  const url = new URL(req.url);
  const phase = url.searchParams.get("phase") ?? "ingest";

  if (phase === "ingest") return handleIngest();
  if (phase === "classify") return handleClassify();

  return Response.json({ error: "Unknown phase" }, { status: 400 });
});
```

**Note:** Ingest still runs via `?phase=ingest` (or no phase) exactly as before.

---

## 2. Classifier implementation — handleClassify()

### Selection

- Fetches up to **30** pending articles per run:
  - `identity_score IS NULL`
  - `summary IS NOT NULL AND summary <> ''`
  - Ordered by `ingested_at ASC` (oldest first)

### Gemini call

- Uses the **canonical Build 3 classifier prompt** (see §12.4 in the handover doc), embedded as `CLASSIFIER_PROMPT_TEMPLATE`.
- For each article, calls Gemini via the existing `GEMINI_URL` (same model config as summarisation for now).
- Cleans ```json fences if present and parses strict JSON.

### DB update

- Interprets `unclassifiable: true` by setting all 4 scores to `NULL`, but still stores the full JSON (including rationale) in `classifier_rationale`.
- On success:
  - Increments `classified` or `unclassifiable` counters in the batch summary.
- On update error:
  - Logs error and increments `errors`.

### Rate limiting

- Processes **30 articles per run**.
- Waits **500ms** between classifier calls to avoid hammering Gemini.

### Response

- Returns a JSON summary per run:

```json
{
  "summary": {
    "requested": 30,
    "processed": N,
    "classified": X,
    "unclassifiable": Y,
    "errors": Z
  },
  "timestamp": "..."
}
```

---

## 3. Aggregation function — refresh_source_ideology_scores

A new Postgres function (already applied via Supabase migration) aggregates article-level scores into `source_ideology_scores`:

```sql
create or replace function refresh_source_ideology_scores()
returns void
language sql
security definer
set search_path = public
as $$
INSERT INTO source_ideology_scores (
  source_id, scored_at, article_sample_count,
  identity_score, state_trust_score, economic_score, institution_score
)
SELECT
  source_id,
  now(),
  count(*) as article_sample_count,
  avg(identity_score)      as identity_score,
  avg(state_trust_score)   as state_trust_score,
  avg(economic_score)      as economic_score,
  avg(institution_score)   as institution_score
FROM articles
WHERE
  identity_score IS NOT NULL
  AND published_at > now() - interval '90 days'
GROUP BY source_id
HAVING count(*) >= 10
ON CONFLICT (source_id)
DO UPDATE SET
  scored_at             = excluded.scored_at,
  article_sample_count  = excluded.article_sample_count,
  identity_score        = excluded.identity_score,
  state_trust_score     = excluded.state_trust_score,
  economic_score        = excluded.economic_score,
  institution_score     = excluded.institution_score;
$$;
```

- `handleClassify()` calls `supabase.rpc("refresh_source_ideology_scores")` after each batch.
- Relies on the UNIQUE(source_id) constraint added in Gate 1 (see PR #18).

---

## 4. New GitHub Actions workflow — classify.yml

`.github/workflows/classify.yml`

- Runs every **2 hours** and supports manual dispatch:

```yaml
name: NewsMirror classify
on:
  schedule:
    - cron: '0 */2 * * *'   # every 2 hours
  workflow_dispatch:
jobs:
  classify:
    runs-on: ubuntu-latest
    steps:
      - name: Classify pending articles
        run: |
          curl -s -X POST \
            "${{ secrets.SUPABASE_URL }}/functions/v1/ingest-articles?phase=classify" \
            -H "Authorization: Bearer ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" \
            -H "Content-Type: application/json" \
            --data '{}'
```

- Uses existing `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` repo secrets.
- With batchSize = 30, this gives up to **360 articles/day** classified once backlog exists.

---

## 5. Classifier prompt + validation notes file

`docs/classifier-prompt-and-validation.txt`

- Stores the **exact canonical classifier prompt** used in code.
- Provides a structured section for manual validation runs (20–30 articles across sources like The Hindu, TOI, Mint, NDTV, Scroll, OpIndia).
- You can improve/tune the prompt here and mirror changes back into `CLASSIFIER_PROMPT_TEMPLATE` in the Edge Function.

---

## Behaviour & Risk Notes

- Ingest pipeline behaviour is unchanged; only routing and the new `phase=classify` behaviour are added.
- Classifier runs in a separate phase and will only start updating existing rows (no schema changes required in this PR).
- Aggregation function is idempotent and safe to run frequently.

---

## Related Issues

Implements:
- #8 — Edge Function phase routing + handleClassify
- #9 — Classifier prompt wired via canonical template (manual validation tracked in docs file)
- #10 — classify.yml scheduled workflow
- #11 — Aggregation into source_ideology_scores via refresh_source_ideology_scores()

Depends on (should be merged first):
- #4/#5 — Gate 1 cleanup (summarise.yml + UNIQUE(source_id))
