### PR TITLE
Build 3 Gate 2 – refine classifier prompt (institutions + soft-content unclassifiable)

### DIFF
--- a/docs/classifier-prompt-and-validation.txt
+++ b/docs/classifier-prompt-and-validation.txt
@@ -34,14 +34,15 @@ AXES:
 
 4. institution_score
    0.0 = Critical or questioning stance toward courts, RBI, Election Commission, press institutions
-   1.0 = Deferential toward institutional decisions, treats institutional authority as legitimate and final
+   1.0 = Deferential toward institutional decisions, treats institutional authority as legitimate and final. Use scores above 0.7 when the article praises these institutions, highlights their wisdom or integrity, or frames criticism as fringe/unreasonable.
    Example 0.2: Article on Supreme Court verdict notes criticism from legal scholars
-   Example 0.9: Article on same verdict treats it as settled and authoritative, no critical voices
+   Example 0.9: Article on same verdict treats it as settled and authoritative, no critical voices, and portrays the court as above reproach
 
 IMPORTANT:
 - Score the framing and editorial choices, NOT the facts reported
 - Many articles will be genuinely neutral on some axes — 0.5 is valid when warranted
 - Short or purely factual articles with no evident framing should return null for all scores
+- Articles that are motivational quotes, celebrity lifestyle, sports recaps, entertainment gossip, or non-political human-interest pieces should be treated as not political and marked unclassifiable.
 - Return ONLY valid JSON, no explanation, no markdown
 
 Headline: {{headline}}
@@ -63,7 +64,7 @@ Return this JSON and nothing else:
   "unclassifiable": false
 }
 
-If the article is too short, purely factual, sports, or entertainment with no political framing,
+If the article is too short, purely factual, sports, celebrity, lifestyle, motivational quote, entertainment, or other non-political human-interest with no political or institutional framing,
 set "unclassifiable": true and all scores to null.
 
 Manual Validation Runs (to be filled by Shubham)

--- a/supabase/functions/ingest-articles/index.ts
+++ b/supabase/functions/ingest-articles/index.ts
@@ -320,14 +320,15 @@ AXES:
 
 4. institution_score
    0.0 = Critical or questioning stance toward courts, RBI, Election Commission, press institutions
-   1.0 = Deferential toward institutional decisions, treats institutional authority as legitimate and final
+   1.0 = Deferential toward institutional decisions, treats institutional authority as legitimate and final. Use scores above 0.7 when the article praises these institutions, highlights their wisdom or integrity, or frames criticism as fringe/unreasonable.
    Example 0.2: Article on Supreme Court verdict notes criticism from legal scholars
-   Example 0.9: Article on same verdict treats it as settled and authoritative, no critical voices
+   Example 0.9: Article on same verdict treats it as settled and authoritative, no critical voices, and portrays the court as above reproach
 
 IMPORTANT:
 - Score the framing and editorial choices, NOT the facts reported
 - Many articles will be genuinely neutral on some axes — 0.5 is valid when warranted
 - Short or purely factual articles with no evident framing should return null for all scores
+- Articles that are motivational quotes, celebrity lifestyle, sports recaps, entertainment gossip, or non-political human-interest pieces should be treated as not political and marked unclassifiable.
 - Return ONLY valid JSON, no explanation, no markdown
 
 Headline: {{headline}}
@@ -349,7 +350,7 @@ Return this JSON and nothing else:
   "unclassifiable": false
 }
 
-If the article is too short, purely factual, sports, or entertainment with no political framing,
+If the article is too short, purely factual, sports, celebrity, lifestyle, motivational quote, entertainment, or other non-political human-interest with no political or institutional framing,
 set "unclassifiable": true and all scores to null.`;
 
 async function classifyArticle(


### PR DESCRIPTION
## What
Small classifier prompt refinement based on first 150+ classified articles in production.

## Changes

1. **Clarify high `institution_score` behaviour**
   - In both the Edge Function prompt (`CLASSIFIER_PROMPT_TEMPLATE`) and `docs/classifier-prompt-and-validation.txt`, expanded the `institution_score` definition:
     - 1.0 now explicitly covers articles that **praise institutions**, highlight their **wisdom or integrity**, or frame criticism as **fringe/unreasonable**.
     - The 0.9 example now mentions portraying the court as **above reproach**.
   - Goal: encourage the model to actually use scores above 0.5 on this axis when coverage is clearly deferential, since early data showed `institution_score` capped at 0.5 even for strongly deferential articles.

2. **Make unclassifiable criteria stricter for soft content**
   - Added explicit guidance that articles which are:
     - Motivational quotes
     - Celebrity lifestyle
     - Sports recaps
     - Entertainment gossip
     - Other non-political human-interest pieces
   - …should be treated as **not political** and marked `unclassifiable: true` with all scores null.
   - Also expanded the final unclassifiable sentence to include: "sports, celebrity, lifestyle, motivational quote, entertainment, or other non-political human-interest with no political or institutional framing".
   - This is based on seeing Mint "Quote of the Day" pieces and similar items getting 0/0/0/0 with `unclassifiable: false` instead of being dropped from the political profile.

## Files touched

- `supabase/functions/ingest-articles/index.ts`
  - Updated `CLASSIFIER_PROMPT_TEMPLATE` text only.
  - No code/logic changes to `classifyArticle` or handlers.

- `docs/classifier-prompt-and-validation.txt`
  - Kept in lockstep with the in-code template so the canonical prompt matches exactly.

## Risk

- Very low: prompt text only, no changes to classification code or DB schema.
- Behavioural expectation:
  - `institution_score` should now start using values above 0.5 where coverage is clearly deferential to courts/RBI/EC.
  - Quote / lifestyle / entertainment content should become `unclassifiable: true` instead of scoring at 0.0 across axes.

After merge, we can re-run the quick SQL checks from Gate 2 QA to confirm:
- `MAX(institution_score)` moves above 0.5 over time.
- Unclassifiable rate for quote-style content increases appropriately, without inflating unclassifiable rates for political outlets.