### PR TITLE
Build 3 Gate 3 UI – public source profiles + lean pill on feed

### DIFF
--- a/app/sources/[id]/page.tsx
+++ b/app/sources/[id]/page.tsx
@@ -1,0 +1,235 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { createClient } from "@/lib/supabase";
+
+export const revalidate = 300;
+
+interface Props {
+  params: { id: string };
+}
+
+export default async function SourceProfilePage({ params }: Props) {
+  const supabase = createClient();
+
+  const { data: source } = await supabase
+    .from("sources")
+    .select("id, name, home_url, language, rss_url")
+    .eq("id", params.id)
+    .maybeSingle();
+
+  if (!source) {
+    return (
+      <main className="max-w-3xl mx-auto px-4 py-16 text-sm text-neutral-400">
+        <p>Source not found.</p>
+      </main>
+    );
+  }
+
+  const { data: profile } = await supabase
+    .from("source_ideology_scores")
+    .select("article_sample_count, identity_score, state_trust_score, economic_score, institution_score")
+    .eq("source_id", source.id)
+    .maybeSingle();
+
+  const { data: examples } = await supabase
+    .from("articles")
+    .select("id, url, headline, summary, identity_score, state_trust_score, economic_score, institution_score, classifier_rationale")
+    .eq("source_id", source.id)
+    .not("summary", "is", null)
+    .not("classifier_rationale", "is", null)
+    .order("published_at", { ascending: false, nullsFirst: false })
+    .limit(3);
+
+  const ready = profile && profile.article_sample_count >= 10;
+
+  const axes = [
+    {
+      key: "identity",
+      label: "Identity framing",
+      description:
+        "How often coverage centres majority vs minority communities, and whether language is plural or majoritarian.",
+    },
+    {
+      key: "state",
+      label: "State narrative",
+      description:
+        "Whether government claims are questioned or largely reproduced at face value, and how often opposition voices appear.",
+    },
+    {
+      key: "economy",
+      label: "Economic framing",
+      description:
+        "Balance between growth and markets on one side, and labour, inequality, or welfare impact on the other.",
+    },
+    {
+      key: "institutions",
+      label: "Institutional tone",
+      description:
+        "How courts, RBI, Election Commission and other watchdogs are described – deferential, neutral, or critical.",
+    },
+  ] as const;
+
+  const axisStrength = (value: number | null | undefined) => {
+    if (value == null) return "Neutral";
+    const diff = Math.abs(value - 0.5);
+    if (diff < 0.15) return "Neutral";
+    if (diff < 0.3) return "Subtle tilt";
+    return "Distinct tilt";
+  };
+
+  return (
+    <main className="max-w-4xl mx-auto px-4 py-10 space-y-10">
+      <header className="space-y-3">
+        <a
+          href="/sources"
+          className="inline-flex items-center gap-1 text-[11px] uppercase tracking-[0.18em] text-neutral-500 hover:text-neutral-300 transition-colors"
+        >
+          <svg width="13" height="13" viewBox="0 0 14 14" fill="none" aria-hidden>
+            <path
+              d="M9 2L4 7l5 5"
+              stroke="currentColor"
+              strokeWidth="1.4"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+          All sources
+        </a>
+        <div className="flex items-center justify-between gap-3">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <span className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-neutral-900 text-sm font-semibold border border-neutral-700">
+                {source.name.charAt(0).toUpperCase()}
+              </span>
+              <div>
+                <h1 className="text-xl sm:text-2xl font-semibold tracking-tight text-white">{source.name}</h1>
+                <p className="text-xs uppercase tracking-[0.16em] text-neutral-500">
+                  {source.language.toUpperCase()} · {ready ? "Profile ready" : "Profile building"}
+                </p>
+              </div>
+            </div>
+          </div>
+          <div className="flex flex-col items-end gap-1 text-right">
+            {source.home_url && (
+              <a
+                href={source.home_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-neutral-400 hover:text-neutral-200 underline-offset-4 hover:underline"
+              >
+                Visit homepage
+              </a>
+            )}
+            {source.rss_url && (
+              <p className="text-[11px] text-neutral-500 truncate max-w-[220px]">
+                {source.rss_url.replace(/^https?:\/\//, "")}
+              </p>
+            )}
+          </div>
+        </div>
+        <p className="text-sm text-neutral-400 max-w-2xl">
+          We infer this profile from how {source.name} has covered stories in the last 90 days – focusing on framing,
+          emphasis and editorial choices, not whether any single article is \"right\" or \"wrong\".
+        </p>
+      </header>
+
+      <section className="grid gap-4 sm:grid-cols-2">
+        {axes.map((axis) => {
+          const rawValue = profile ? (profile as any)[`${axis.key}_score`] ?? null : null;
+          const strength = axisStrength(rawValue);
+          return (
+            <div
+              key={axis.key}
+              className="rounded-2xl border border-neutral-800 bg-neutral-950/70 px-4 py-4 flex flex-col gap-3"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.18em] text-neutral-500">{axis.label}</p>
+                  <p className="text-[11px] text-neutral-400">{strength}</p>
+                </div>
+                <div className="flex flex-col items-end gap-1">
+                  <span className="inline-flex h-1.5 w-16 overflow-hidden rounded-full bg-neutral-800">
+                    <span
+                      className="h-full bg-emerald-400/80"
+                      style={{
+                        width:
+                          rawValue == null
+                            ? "40%"
+                            : `${30 + Math.round(Math.abs(rawValue - 0.5) * 70)}%`,
+                      }}
+                    />
+                  </span>
+                  <span className="text-[10px] text-neutral-500">Relative editorial weight</span>
+                </div>
+              </div>
+              <p className="text-xs text-neutral-400 leading-relaxed">{axis.description}</p>
+            </div>
+          );
+        })}
+      </section>
+
+      {examples && examples.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-sm font-medium tracking-tight text-white">Representative recent stories</h2>
+          <p className="text-xs text-neutral-500 max-w-xl">
+            A few of the stories the model looked at when shaping this profile. Rationale snippets are generated and
+            may not match your reading perfectly, but they show the kind of framing we track.
+          </p>
+          <div className="space-y-3">
+            {examples.map((a: any) => (
+              <a
+                key={a.id}
+                href={a.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block rounded-2xl border border-neutral-800 bg-neutral-950/60 px-4 py-3 hover:border-neutral-700 hover:bg-neutral-900/70 transition-colors"
+              >
+                <p className="text-xs text-neutral-500 mb-1">Story</p>
+                <p className="text-sm font-medium text-white mb-1 line-clamp-2">{a.headline}</p>
+                {a.summary && (
+                  <p className="text-xs text-neutral-400 line-clamp-3 mb-2">{a.summary}</p>
+                )}
+                {a.classifier_rationale?.rationale && (
+                  <div className="mt-1 grid gap-1.5 text-[11px] text-neutral-400 sm:grid-cols-2">
+                    {a.classifier_rationale.rationale.identity && (
+                      <p>
+                        <span className="text-neutral-500">Identity: </span>
+                        {a.classifier_rationale.rationale.identity}
+                      </p>
+                    )}
+                    {a.classifier_rationale.rationale.state_trust && (
+                      <p>
+                        <span className="text-neutral-500">State: </span>
+                        {a.classifier_rationale.rationale.state_trust}
+                      </p>
+                    )}
+                    {a.classifier_rationale.rationale.economic && (
+                      <p>
+                        <span className="text-neutral-500">Economy: </span>
+                        {a.classifier_rationale.rationale.economic}
+                      </p>
+                    )}
+                    {a.classifier_rationale.rationale.institution && (
+                      <p>
+                        <span className="text-neutral-500">Institutions: </span>
+                        {a.classifier_rationale.rationale.institution}
+                      </p>
+                    )}
+                  </div>
+                )}
+              </a>
+            ))}
+          </div>
+        </section>
+      )}
+
+      <section className="border-t border-neutral-900 pt-6 mt-4">
+        <h2 className="text-xs uppercase tracking-[0.2em] text-neutral-500 mb-2">How this works</h2>
+        <p className="text-xs text-neutral-500 max-w-2xl">
+          We never label any outlet as \"good\" or \"bad\". Instead, we look at framing choices across many articles –
+          which voices are quoted, what gets emphasised, and how often institutions are questioned or praised. Raw
+          model scores stay behind the scenes; what you see here is a softened, human-readable summary.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/app/sources/page.tsx
+++ b/app/sources/page.tsx
@@ -1,0 +1,87 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { createClient } from "@/lib/supabase";
+
+export const revalidate = 300;
+
+export default async function SourcesPage() {
+  const supabase = createClient();
+
+  const { data: sources } = await supabase
+    .from("sources")
+    .select("id, name, home_url, language")
+    .order("name");
+
+  const { data: profiles } = await supabase
+    .from("source_ideology_scores")
+    .select("source_id, article_sample_count, identity_score, state_trust_score, economic_score, institution_score");
+
+  const profileMap = new Map<string, any>();
+  for (const row of profiles ?? []) {
+    profileMap.set(row.source_id, row);
+  }
+
+  const enriched = (sources ?? []).map((s: any) => ({
+    ...s,
+    profile: profileMap.get(s.id) ?? null,
+  }));
+
+  return (
+    <main className="max-w-5xl mx-auto px-4 py-10 space-y-8">
+      <header className="space-y-2">
+        <p className="text-xs uppercase tracking-[0.2em] text-neutral-500">NewsMirror</p>
+        <h1 className="text-2xl sm:text-3xl font-semibold tracking-tight">Sources & editorial profiles</h1>
+        <p className="text-sm text-neutral-500 max-w-xl">
+          We read each outlet over the last 90 days and infer a soft profile of how it frames identity, the state,
+          the economy, and institutions. No raw scores are shown here; only relative tendencies.
+        </p>
+      </header>
+
+      <section className="grid gap-4 sm:grid-cols-2">
+        {enriched.map((source) => {
+          const p = source.profile;
+          const ready = p && p.article_sample_count >= 10;
+          return (
+            <a
+              key={source.id}
+              href={`/sources/${source.id}`}
+              className="group rounded-2xl border border-neutral-800 bg-neutral-950/60 px-4 py-4 flex flex-col gap-3 hover:border-neutral-700 hover:bg-neutral-900/70 transition-colors"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <div className="space-y-0.5">
+                  <div className="text-sm font-medium tracking-tight text-white flex items-center gap-1.5">
+                    <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-neutral-900 text-[11px] font-semibold border border-neutral-700">
+                      {source.name.charAt(0).toUpperCase()}
+                    </span>
+                    <span>{source.name}</span>
+                  </div>
+                  <p className="text-[11px] uppercase tracking-[0.16em] text-neutral-500">
+                    {source.language.toUpperCase()} · {ready ? "Profile ready" : "Profile building"}
+                  </p>
+                </div>
+                {ready && (
+                  <div className="flex items-center gap-1 text-[11px] text-neutral-400">
+                    <span className="inline-flex h-1.5 w-10 overflow-hidden rounded-full bg-neutral-800">
+                      <span className="h-full w-1/2 bg-amber-400/80 group-hover:bg-amber-300/90 transition-colors" />
+                    </span>
+                    <span>View stance</span>
+                  </div>
+                )}
+              </div>
+
+              {ready ? (
+                <p className="text-xs text-neutral-400 leading-relaxed">
+                  Based on {p.article_sample_count} recent stories, this outlet shows a distinct editorial pattern across identity,
+                  the state, economy, and institutions.
+                </p>
+              ) : (
+                <p className="text-xs text-neutral-500 leading-relaxed">
+                  We are still reading this outlet. A profile appears once we have at least 10 representative articles.
+                </p>
+              )}
+            </a>
+          );
+        })}
+      </section>
+    </main>
+  );
+}

--- a/components/feed/StoryCard.module.css
+++ b/components/feed/StoryCard.module.css
@@ -100,6 +100,55 @@
   color: var(--accent);
 }
 
+.leanPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.7);
+  background: rgba(0, 0, 0, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.leanPill_identity {
+  border-color: rgba(252, 211, 77, 0.4);
+}
+
+.leanPill_state {
+  border-color: rgba(52, 211, 153, 0.4);
+}
+
+.leanPill_economy {
+  border-color: rgba(59, 130, 246, 0.4);
+}
+
+.leanPill_institutions {
+  border-color: rgba(244, 114, 182, 0.4);
+}
+
+.leanPill_low {
+  opacity: 0.75;
+}
+
+.leanPill_high {
+  opacity: 1;
+}
+
+.leanDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.leanLabel {
+  white-space: nowrap;
+}
+
 .tag {
   font-size: 10px;
   color: rgba(255, 255, 255, 0.65);

--- a/components/feed/StoryCard.tsx
+++ b/components/feed/StoryCard.tsx
@@ -22,6 +22,50 @@ interface Props {
   total: number;
 }
 
+function getLeanMeta(article: Article):
+  | { label: string; strength: "low" | "high"; axis: "identity" | "state" | "economy" | "institutions" }
+  | null {
+  const { identity_score, state_trust_score, economic_score, institution_score } = article;
+
+  const scores: { axis: "identity" | "state" | "economy" | "institutions"; value: number | null }[] = [
+    { axis: "identity", value: identity_score },
+    { axis: "state", value: state_trust_score },
+    { axis: "economy", value: economic_score },
+    { axis: "institutions", value: institution_score },
+  ];
+
+  const withDiff = scores
+    .filter((s) => typeof s.value === "number")
+    .map((s) => ({ ...s, diff: Math.abs((s.value as number) - 0.5) }));
+
+  if (!withDiff.length) return null;
+
+  const dominant = withDiff.reduce((best, curr) => (curr.diff > best.diff ? curr : best));
+
+  // Ignore very small deviations from neutral
+  if (dominant.diff < 0.12) return null;
+
+  const strength: "low" | "high" = dominant.diff >= 0.25 ? "high" : "low";
+
+  let label = "";
+  switch (dominant.axis) {
+    case "identity":
+      label = "Identity framing";
+      break;
+    case "state":
+      label = "State narrative";
+      break;
+    case "economy":
+      label = "Economic framing";
+      break;
+    case "institutions":
+      label = "Institutional tone";
+      break;
+  }
+
+  return { label, strength, axis: dominant.axis };
+}
+
 export default function StoryCard({ article, isActive, position, total }: Props) {
   const [saved, setSaved] = useState(false);
   const [imgFailed, setImgFailed] = useState(false);
@@ -29,6 +73,7 @@ export default function StoryCard({ article, isActive, position, total }: Props)
   const sourceName = article.sources?.name ?? "Unknown";
   const age = timeAgo(article.published_at ?? article.ingested_at);
   const tag = article.topic_tags?.[0];
+  const leanMeta = getLeanMeta(article);
 
   return (
     <article
@@ -56,17 +101,32 @@ export default function StoryCard({ article, isActive, position, total }: Props)
         <div className={styles.topBar}>
           <div className={styles.metaPill}>
             <span className={styles.source}>{sourceName}</span>
+            {leanMeta && (
+              <span
+                className={`${styles.leanPill} ${styles[`leanPill_${leanMeta.axis}`]} ${styles[`leanPill_${leanMeta.strength}`]}`}
+                title={leanMeta.label}
+              >
+                <span className={styles.leanDot} aria-hidden />
+                <span className={styles.leanLabel}>{leanMeta.label}</span>
+              </span>
+            )}
             {tag && (
               <>
-                <span className={styles.metaDivider} aria-hidden>·</span>
+                <span className={styles.metaDivider} aria-hidden>
+                  ·
+                </span>
                 <span className={styles.tag}>{tag}</span>
               </>
             )}
           </div>
           <div className={styles.metaPill}>
             <span className={styles.age}>{age}</span>
-            <span className={styles.metaDivider} aria-hidden>·</span>
-            <span className={styles.counter}>{position}/{total}</span>
+            <span className={styles.metaDivider} aria-hidden>
+              ·
+            </span>
+            <span className={styles.counter}>
+              {position}/{total}
+            </span>
           </div>
         </div>
 
@@ -77,9 +137,7 @@ export default function StoryCard({ article, isActive, position, total }: Props)
         <div className={styles.body}>
           <h2 className={styles.headline}>{article.headline}</h2>
 
-          {article.summary && (
-            <p className={styles.summary}>{article.summary}</p>
-          )}
+          {article.summary && <p className={styles.summary}>{article.summary}</p>}
 
           {/* ── Actions ── */}
           <div className={styles.actions}>
@@ -91,7 +149,13 @@ export default function StoryCard({ article, isActive, position, total }: Props)
             >
               Read full story
               <svg width="11" height="11" viewBox="0 0 11 11" fill="none" aria-hidden>
-                <path d="M1 10L10 1M10 1H4M10 1V7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                <path
+                  d="M1 10L10 1M10 1H4M10 1V7"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
               </svg>
             </a>
 


### PR DESCRIPTION
## What
First cut of the public-facing UI for classifier output:

1. **Lean pill on feed story cards**
   - Uses per-article ideology scores to derive a soft, qualitative indicator in the StoryCard header.
   - No raw numbers are shown; instead we:
     - Compute the dominant axis as the one furthest from 0.5 among `identity_score`, `state_trust_score`, `economic_score`, `institution_score`.
     - Drop the indicator entirely when the dominant deviation is very small (< 0.12 from neutral).
     - Bucket into `low` vs `high` strength at a diff of 0.25.
   - UI:
     - A small frosted-glass pill inside the existing source meta pill, with a coloured border and dot:
       - identity → warm amber border
       - state → emerald border
       - economy → blue border
       - institutions → pink border
     - Label text: `Identity framing`, `State narrative`, `Economic framing`, or `Institutional tone`.
   - Behaviour:
     - If an article has no scores yet (nulls), the lean pill is omitted.
     - This keeps the feed minimal while giving a visual hint of what kind of stance the model is picking up on that particular story.

2. **New `/sources` page (public sources list)**
   - Server component at `app/sources/page.tsx`.
   - Fetches:
     - `sources`: `id, name, home_url, language`.
     - `source_ideology_scores`: `source_id, article_sample_count, identity_score, state_trust_score, economic_score, institution_score`.
   - Merges them server-side into an `enriched` array with an optional `profile` per source.
   - UI:
     - Page header explaining that we infer profiles from the last 90 days and do **not** show raw model scores.
     - Grid of source cards (2 columns on desktop):
       - Left: source initial-avatar + name and `LANG · Profile ready/Profile building` meta line.
       - Right (for ready profiles): tiny bar motif + label `View stance` to hint at a deeper profile.
       - Body text differs:
         - `Profile ready`: mentions article_sample_count and that the outlet shows a distinct pattern across axes.
         - `Profile building`: short explanation that a profile appears once we have at least 10 representative articles.
     - Cards link through to `/sources/:id` for the full profile.

3. **New `/sources/[id]` source profile page**
   - Server component at `app/sources/[id]/page.tsx`.
   - Fetches, for a given source id:
     - `sources`: `id, name, home_url, language, rss_url`.
     - `source_ideology_scores`: `article_sample_count, identity_score, state_trust_score, economic_score, institution_score`.
     - Up to 3 recent `articles` with non-null `classifier_rationale` for representative examples.
   - Layout:
     - Header with back link to `/sources`, avatar initial, name, language, `Profile ready/Profile building` chip, homepage link, and RSS snippet.
     - Intro paragraph that explains we look at framing over the last 90 days and do not treat any single article as "right" or "wrong".
   - Axis cards section:
     - Four cards: Identity framing, State narrative, Economic framing, Institutional tone.
     - For each axis we:
       - Read the corresponding `*_score` from `source_ideology_scores`.
       - Map the absolute deviation from 0.5 into: `Neutral`, `Subtle tilt`, or `Distinct tilt` (no numbers rendered).
       - Show a small bar (width mapped to 30–100% based on deviation only, not direction) with caption `Relative editorial weight`.
       - Include a 1–2 line human explanation for what that axis means.
   - Representative stories section:
     - If we have any examples, we render up to 3 tiles:
       - Headline (linking out), summary, and a small grid of rationale snippets.
       - Each snippet is prefixed with axis label (`Identity:`, `State:`, `Economy:`, `Institutions:`) and shows the corresponding one-sentence rationale from `classifier_rationale.rationale`.
     - Copy explicitly notes that these are generated explanations and are just a window into what the model is tracking.
   - Methodology blurb at bottom:
     - Reiterates that we do not label outlets as "good" or "bad" and that raw scores stay behind the scenes.

## Files touched

- `app/feed/page.tsx`
  - Kept the existing query shape but clarified the selection for readability.
  - No behavioural changes other than passing through ideology-related fields to the client as before.

- `components/feed/StoryCard.tsx`
  - Added a small helper, `getLeanMeta(article)`, that inspects the four score fields and returns a dominant axis + strength bucket or `null`.
  - Injected a new `leanMeta` pill into the left meta pill alongside the source name.
  - No changes to existing time, tag, or actions behaviour.

- `components/feed/StoryCard.module.css`
  - Added styles for the lean pill (`.leanPill`, axis-specific border modifiers, strength modifiers) and its dot/label.
  - Kept existing layout and visual language (frosted glass, accent colour, typography) intact.

- `app/sources/page.tsx`
  - New server route implementing the public sources index as described above.

- `app/sources/[id]/page.tsx`
  - New server route implementing the source profile page with axis cards and representative stories.

## Behaviour & constraints

- No raw numeric model scores are displayed anywhere in the UI.
- All visual encodings (lean pill, axis bars) are qualitative: they depend on *magnitude of deviation from neutral* only, not the absolute numeric values.
- Source profiles only considered "ready" once `article_sample_count >= 10`, matching the aggregation spec.

## Follow-ups / Ideas

- Add navigation entry points to `/sources` from the main shell (e.g. header link or footer).
- Once we are happy with profiles, consider replacing the per-article lean pill with a per-source pill that reads from `source_ideology_scores` instead of the individual article scores, to further stabilise the signal.
- Later we can expand the profile with topic-specific views (e.g. "On courts", "On economy") once we wire topic_tags into the aggregation.
