### PR TITLE
Fix sources pages: replace Tailwind with CSS modules

### DIFF
--- a/app/sources/Sources.module.css
+++ b/app/sources/Sources.module.css
@@ -1,0 +1,152 @@
+.page {
+  min-height: 100dvh;
+  background: var(--bg);
+  padding: 0 0 4rem;
+  overflow-y: auto;
+}
+
+.container {
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
+/* Header */
+.header {
+  padding: 1.5rem 0 1.5rem;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 1.5rem;
+}
+
+.backLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  margin-bottom: 0.85rem;
+  transition: color 0.15s;
+}
+
+.backLink:hover { color: var(--text-secondary); }
+
+.title {
+  font-family: var(--font-display);
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--text-primary);
+  letter-spacing: -0.02em;
+  margin-bottom: 0.5rem;
+}
+
+.subtitle {
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+  max-width: 520px;
+}
+
+/* Source grid */
+.grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+/* Card */
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  padding: 1rem 1rem 0.9rem;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.card:hover {
+  border-color: var(--border-hover);
+  background: var(--surface-2);
+}
+
+.cardTop {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.avatar {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--surface-2);
+  border: 1px solid var(--border-hover);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.cardMeta {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.cardName {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cardStatus {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.langPill {
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+  background: var(--surface-2);
+  padding: 1px 6px;
+  border-radius: 99px;
+}
+
+.statusReady {
+  font-size: 11px;
+  color: #5dcaa5;
+}
+
+.statusBuilding {
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+
+.chevron {
+  flex-shrink: 0;
+  color: var(--text-tertiary);
+  transition: color 0.15s;
+}
+
+.card:hover .chevron {
+  color: var(--text-secondary);
+}
+
+.cardBody {
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--text-secondary);
+  padding-left: calc(32px + 0.75rem);
+}

--- a/app/sources/[id]/SourceProfile.module.css
+++ b/app/sources/[id]/SourceProfile.module.css
@@ -1,0 +1,314 @@
+.page {
+  min-height: 100dvh;
+  background: var(--bg);
+  padding: 0 0 5rem;
+  overflow-y: auto;
+}
+
+.container {
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
+.notFound {
+  padding: 4rem 0;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+/* Header */
+.header {
+  padding: 1.5rem 0 1.5rem;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 1.75rem;
+}
+
+.backLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  margin-bottom: 1rem;
+  transition: color 0.15s;
+}
+
+.backLink:hover { color: var(--text-secondary); }
+
+.sourceHeader {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.85rem;
+  margin-bottom: 0.85rem;
+}
+
+.avatar {
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--surface);
+  border: 1px solid var(--border-hover);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.sourceHeaderMeta {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  min-width: 0;
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--text-primary);
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+
+.statusRow {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.langPill {
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+  background: var(--surface-2);
+  padding: 1px 7px;
+  border-radius: 99px;
+}
+
+.statusReady {
+  font-size: 11px;
+  color: #5dcaa5;
+}
+
+.statusBuilding {
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+
+.homepageLink {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--accent);
+  transition: opacity 0.15s;
+  padding-top: 2px;
+}
+
+.homepageLink:hover { opacity: 0.75; }
+
+.intro {
+  font-size: 13px;
+  line-height: 1.65;
+  color: var(--text-secondary);
+}
+
+/* Sections */
+.section {
+  margin-bottom: 2rem;
+}
+
+.sectionTitle {
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-tertiary);
+  margin-bottom: 0.85rem;
+}
+
+.sectionHint {
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--text-tertiary);
+  margin-bottom: 0.85rem;
+}
+
+/* Axis grid */
+.axisGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.6rem;
+}
+
+@media (max-width: 480px) {
+  .axisGrid { grid-template-columns: 1fr; }
+}
+
+.axisCard {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.axisTop {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.axisLabel {
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-tertiary);
+  margin-bottom: 0.2rem;
+}
+
+.axisStrength {
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.strengthNeutral   { color: var(--text-secondary); }
+.strengthSubtle    { color: #9dcfff; }
+.strengthDistinct  { color: var(--accent); }
+
+.barWrap {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.3rem;
+  flex-shrink: 0;
+}
+
+.barTrack {
+  width: 56px;
+  height: 4px;
+  border-radius: 99px;
+  background: var(--surface-2);
+  overflow: hidden;
+}
+
+.barFill {
+  height: 100%;
+  border-radius: 99px;
+  background: var(--accent);
+  opacity: 0.6;
+  transition: width 0.3s ease;
+}
+
+.barCaption {
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+}
+
+.axisDesc {
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--text-secondary);
+}
+
+/* Representative stories */
+.exampleList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.exampleCard {
+  display: block;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  padding: 1rem;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.exampleCard:hover {
+  border-color: var(--border-hover);
+  background: var(--surface-2);
+}
+
+.exampleHeadline {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-primary);
+  line-height: 1.4;
+  margin-bottom: 0.4rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.exampleSummary {
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--text-secondary);
+  margin-bottom: 0.75rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.rationaleGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.4rem 0.75rem;
+  border-top: 1px solid var(--border);
+  padding-top: 0.65rem;
+}
+
+@media (max-width: 480px) {
+  .rationaleGrid { grid-template-columns: 1fr; }
+}
+
+.rationaleItem {
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+.rationaleAxis {
+  font-weight: 500;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 10px;
+  margin-right: 2px;
+}
+
+/* Methodology note */
+.methodNote {
+  border-top: 1px solid var(--border);
+  padding-top: 1.25rem;
+  margin-top: 0.5rem;
+}
+
+.methodText {
+  font-size: 12px;
+  line-height: 1.65;
+  color: var(--text-tertiary);
+  max-width: 560px;
+}

--- a/app/sources/[id]/page.tsx
+++ b/app/sources/[id]/page.tsx
@@ -1,10 +1,51 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { createClient } from "@/lib/supabase";
+import styles from "./SourceProfile.module.css";
 
 export const revalidate = 300;
 
 interface Props {
   params: { id: string };
+}
+
+const AXES = [
+  {
+    key: "identity_score",
+    label: "Identity framing",
+    description:
+      "How often coverage centres majority vs minority communities, and whether language is plural or majoritarian.",
+  },
+  {
+    key: "state_trust_score",
+    label: "State narrative",
+    description:
+      "Whether government claims are questioned or largely reproduced at face value, and how often opposition voices appear.",
+  },
+  {
+    key: "economic_score",
+    label: "Economic framing",
+    description:
+      "Balance between growth and markets on one side, and labour, inequality, or welfare impact on the other.",
+  },
+  {
+    key: "institution_score",
+    label: "Institutional tone",
+    description:
+      "How courts, RBI, Election Commission and other watchdogs are described – deferential, neutral, or critical.",
+  },
+] as const;
+
+function axisStrength(value: number | null | undefined): "Neutral" | "Subtle tilt" | "Distinct tilt" {
+  if (value == null) return "Neutral";
+  const diff = Math.abs(value - 0.5);
+  if (diff < 0.15) return "Neutral";
+  if (diff < 0.3) return "Subtle tilt";
+  return "Distinct tilt";
+}
+
+function barWidth(value: number | null | undefined): number {
+  if (value == null) return 30;
+  return Math.round(30 + Math.abs(value - 0.5) * 70);
 }
 
 export default async function SourceProfilePage({ params }: Props) {
@@ -18,9 +59,11 @@ export default async function SourceProfilePage({ params }: Props) {
 
   if (!source) {
     return (
-      <main className="max-w-3xl mx-auto px-4 py-16 text-sm text-neutral-400">
-        <p>Source not found.</p>
-      </main>
+      <div className={styles.page}>
+        <div className={styles.container}>
+          <p className={styles.notFound}>Source not found.</p>
+        </div>
+      </div>
     );
   }
 
@@ -32,7 +75,7 @@ export default async function SourceProfilePage({ params }: Props) {
 
   const { data: examples } = await supabase
     .from("articles")
-    .select("id, url, headline, summary, identity_score, state_trust_score, economic_score, institution_score, classifier_rationale")
+    .select("id, url, headline, summary, classifier_rationale")
     .eq("source_id", source.id)
     .not("summary", "is", null)
     .not("classifier_rationale", "is", null)
@@ -41,195 +84,151 @@ export default async function SourceProfilePage({ params }: Props) {
 
   const ready = profile && profile.article_sample_count >= 10;
 
-  const axes = [
-    {
-      key: "identity",
-      label: "Identity framing",
-      description:
-        "How often coverage centres majority vs minority communities, and whether language is plural or majoritarian.",
-    },
-    {
-      key: "state",
-      label: "State narrative",
-      description:
-        "Whether government claims are questioned or largely reproduced at face value, and how often opposition voices appear.",
-    },
-    {
-      key: "economy",
-      label: "Economic framing",
-      description:
-        "Balance between growth and markets on one side, and labour, inequality, or welfare impact on the other.",
-    },
-    {
-      key: "institutions",
-      label: "Institutional tone",
-      description:
-        "How courts, RBI, Election Commission and other watchdogs are described – deferential, neutral, or critical.",
-    },
-  ] as const;
-
-  const axisStrength = (value: number | null | undefined) => {
-    if (value == null) return "Neutral";
-    const diff = Math.abs(value - 0.5);
-    if (diff < 0.15) return "Neutral";
-    if (diff < 0.3) return "Subtle tilt";
-    return "Distinct tilt";
-  };
-
   return (
-    <main className="max-w-4xl mx-auto px-4 py-10 space-y-10">
-      <header className="space-y-3">
-        <a
-          href="/sources"
-          className="inline-flex items-center gap-1 text-[11px] uppercase tracking-[0.18em] text-neutral-500 hover:text-neutral-300 transition-colors"
-        >
-          <svg width="13" height="13" viewBox="0 0 14 14" fill="none" aria-hidden>
-            <path
-              d="M9 2L4 7l5 5"
-              stroke="currentColor"
-              strokeWidth="1.4"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-          All sources
-        </a>
-        <div className="flex items-center justify-between gap-3">
-          <div className="space-y-1">
-            <div className="flex items-center gap-2">
-              <span className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-neutral-900 text-sm font-semibold border border-neutral-700">
-                {source.name.charAt(0).toUpperCase()}
-              </span>
-              <div>
-                <h1 className="text-xl sm:text-2xl font-semibold tracking-tight text-white">{source.name}</h1>
-                <p className="text-xs uppercase tracking-[0.16em] text-neutral-500">
-                  {source.language.toUpperCase()} · {ready ? "Profile ready" : "Profile building"}
-                </p>
+    <div className={styles.page}>
+      <div className={styles.container}>
+        {/* Header */}
+        <header className={styles.header}>
+          <a href="/sources" className={styles.backLink}>
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+              <path d="M9 2L4 7l5 5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+            All sources
+          </a>
+
+          <div className={styles.sourceHeader}>
+            <div className={styles.avatar}>{source.name.charAt(0).toUpperCase()}</div>
+            <div className={styles.sourceHeaderMeta}>
+              <h1 className={styles.title}>{source.name}</h1>
+              <div className={styles.statusRow}>
+                <span className={styles.langPill}>{source.language.toUpperCase()}</span>
+                {ready ? (
+                  <span className={styles.statusReady}>Profile ready · {profile.article_sample_count} articles</span>
+                ) : (
+                  <span className={styles.statusBuilding}>Profile building</span>
+                )}
               </div>
             </div>
-          </div>
-          <div className="flex flex-col items-end gap-1 text-right">
             {source.home_url && (
               <a
                 href={source.home_url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-xs text-neutral-400 hover:text-neutral-200 underline-offset-4 hover:underline"
+                className={styles.homepageLink}
               >
-                Visit homepage
+                Visit
+                <svg width="10" height="10" viewBox="0 0 11 11" fill="none" aria-hidden>
+                  <path d="M1 10L10 1M10 1H4M10 1V7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
               </a>
-            )}
-            {source.rss_url && (
-              <p className="text-[11px] text-neutral-500 truncate max-w-[220px]">
-                {source.rss_url.replace(/^https?:\/\//, "")}
-              </p>
             )}
           </div>
-        </div>
-        <p className="text-sm text-neutral-400 max-w-2xl">
-          We infer this profile from how {source.name} has covered stories in the last 90 days – focusing on framing,
-          emphasis and editorial choices, not whether any single article is \"right\" or \"wrong\".
-        </p>
-      </header>
 
-      <section className="grid gap-4 sm:grid-cols-2">
-        {axes.map((axis) => {
-          const rawValue = profile ? (profile as any)[`${axis.key}_score`] ?? null : null;
-          const strength = axisStrength(rawValue);
-          return (
-            <div
-              key={axis.key}
-              className="rounded-2xl border border-neutral-800 bg-neutral-950/70 px-4 py-4 flex flex-col gap-3"
-            >
-              <div className="flex items-center justify-between gap-2">
-                <div>
-                  <p className="text-xs uppercase tracking-[0.18em] text-neutral-500">{axis.label}</p>
-                  <p className="text-[11px] text-neutral-400">{strength}</p>
-                </div>
-                <div className="flex flex-col items-end gap-1">
-                  <span className="inline-flex h-1.5 w-16 overflow-hidden rounded-full bg-neutral-800">
-                    <span
-                      className="h-full bg-emerald-400/80"
-                      style={{
-                        width:
-                          rawValue == null
-                            ? "40%"
-                            : `${30 + Math.round(Math.abs(rawValue - 0.5) * 70)}%`,
-                      }}
-                    />
-                  </span>
-                  <span className="text-[10px] text-neutral-500">Relative editorial weight</span>
-                </div>
-              </div>
-              <p className="text-xs text-neutral-400 leading-relaxed">{axis.description}</p>
-            </div>
-          );
-        })}
-      </section>
-
-      {examples && examples.length > 0 && (
-        <section className="space-y-3">
-          <h2 className="text-sm font-medium tracking-tight text-white">Representative recent stories</h2>
-          <p className="text-xs text-neutral-500 max-w-xl">
-            A few of the stories the model looked at when shaping this profile. Rationale snippets are generated and
-            may not match your reading perfectly, but they show the kind of framing we track.
+          <p className={styles.intro}>
+            We infer this profile from how {source.name} has covered stories in the last 90 days — focusing on
+            framing, emphasis, and editorial choices, not whether any single article is correct.
           </p>
-          <div className="space-y-3">
-            {examples.map((a: any) => (
-              <a
-                key={a.id}
-                href={a.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block rounded-2xl border border-neutral-800 bg-neutral-950/60 px-4 py-3 hover:border-neutral-700 hover:bg-neutral-900/70 transition-colors"
-              >
-                <p className="text-xs text-neutral-500 mb-1">Story</p>
-                <p className="text-sm font-medium text-white mb-1 line-clamp-2">{a.headline}</p>
-                {a.summary && (
-                  <p className="text-xs text-neutral-400 line-clamp-3 mb-2">{a.summary}</p>
-                )}
-                {a.classifier_rationale?.rationale && (
-                  <div className="mt-1 grid gap-1.5 text-[11px] text-neutral-400 sm:grid-cols-2">
-                    {a.classifier_rationale.rationale.identity && (
-                      <p>
-                        <span className="text-neutral-500">Identity: </span>
-                        {a.classifier_rationale.rationale.identity}
+        </header>
+
+        {/* Axis cards */}
+        <section className={styles.section}>
+          <h2 className={styles.sectionTitle}>Editorial dimensions</h2>
+          <div className={styles.axisGrid}>
+            {AXES.map((axis) => {
+              const rawValue = profile ? (profile as any)[axis.key] ?? null : null;
+              const strength = axisStrength(rawValue);
+              const width = barWidth(rawValue);
+              return (
+                <div key={axis.key} className={styles.axisCard}>
+                  <div className={styles.axisTop}>
+                    <div>
+                      <p className={styles.axisLabel}>{axis.label}</p>
+                      <p className={`${styles.axisStrength} ${
+                        strength === "Distinct tilt" ? styles.strengthDistinct
+                        : strength === "Subtle tilt" ? styles.strengthSubtle
+                        : styles.strengthNeutral
+                      }`}>
+                        {ready ? strength : "—"}
                       </p>
-                    )}
-                    {a.classifier_rationale.rationale.state_trust && (
-                      <p>
-                        <span className="text-neutral-500">State: </span>
-                        {a.classifier_rationale.rationale.state_trust}
-                      </p>
-                    )}
-                    {a.classifier_rationale.rationale.economic && (
-                      <p>
-                        <span className="text-neutral-500">Economy: </span>
-                        {a.classifier_rationale.rationale.economic}
-                      </p>
-                    )}
-                    {a.classifier_rationale.rationale.institution && (
-                      <p>
-                        <span className="text-neutral-500">Institutions: </span>
-                        {a.classifier_rationale.rationale.institution}
-                      </p>
-                    )}
+                    </div>
+                    <div className={styles.barWrap}>
+                      <div className={styles.barTrack}>
+                        <div className={styles.barFill} style={{ width: ready ? `${width}%` : "30%" }} />
+                      </div>
+                      <p className={styles.barCaption}>Relative editorial weight</p>
+                    </div>
                   </div>
-                )}
-              </a>
-            ))}
+                  <p className={styles.axisDesc}>{axis.description}</p>
+                </div>
+              );
+            })}
           </div>
         </section>
-      )}
 
-      <section className="border-t border-neutral-900 pt-6 mt-4">
-        <h2 className="text-xs uppercase tracking-[0.2em] text-neutral-500 mb-2">How this works</h2>
-        <p className="text-xs text-neutral-500 max-w-2xl">
-          We never label any outlet as \"good\" or \"bad\". Instead, we look at framing choices across many articles –
-          which voices are quoted, what gets emphasised, and how often institutions are questioned or praised. Raw
-          model scores stay behind the scenes; what you see here is a softened, human-readable summary.
-        </p>
-      </section>
-    </main>
+        {/* Representative stories */}
+        {examples && examples.length > 0 && (
+          <section className={styles.section}>
+            <h2 className={styles.sectionTitle}>Representative recent stories</h2>
+            <p className={styles.sectionHint}>
+              A few of the stories the model examined when shaping this profile. Rationale snippets are
+              generated and show the framing the model is tracking — not verdicts on the article.
+            </p>
+            <div className={styles.exampleList}>
+              {examples.map((a: any) => (
+                <a
+                  key={a.id}
+                  href={a.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={styles.exampleCard}
+                >
+                  <p className={styles.exampleHeadline}>{a.headline}</p>
+                  {a.summary && (
+                    <p className={styles.exampleSummary}>{a.summary}</p>
+                  )}
+                  {a.classifier_rationale?.rationale && (
+                    <div className={styles.rationaleGrid}>
+                      {a.classifier_rationale.rationale.identity && (
+                        <p className={styles.rationaleItem}>
+                          <span className={styles.rationaleAxis}>Identity </span>
+                          {a.classifier_rationale.rationale.identity}
+                        </p>
+                      )}
+                      {a.classifier_rationale.rationale.state_trust && (
+                        <p className={styles.rationaleItem}>
+                          <span className={styles.rationaleAxis}>State </span>
+                          {a.classifier_rationale.rationale.state_trust}
+                        </p>
+                      )}
+                      {a.classifier_rationale.rationale.economic && (
+                        <p className={styles.rationaleItem}>
+                          <span className={styles.rationaleAxis}>Economy </span>
+                          {a.classifier_rationale.rationale.economic}
+                        </p>
+                      )}
+                      {a.classifier_rationale.rationale.institution && (
+                        <p className={styles.rationaleItem}>
+                          <span className={styles.rationaleAxis}>Institutions </span>
+                          {a.classifier_rationale.rationale.institution}
+                        </p>
+                      )}
+                    </div>
+                  )}
+                </a>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Methodology note */}
+        <section className={styles.methodNote}>
+          <p className={styles.methodText}>
+            We never label any outlet as &ldquo;good&rdquo; or &ldquo;bad&rdquo;. Instead, we look at framing choices
+            across many articles — which voices are quoted, what gets emphasised, and how often institutions are questioned
+            or praised. Raw model scores stay behind the scenes; what you see here is a softened, human-readable summary.
+          </p>
+        </section>
+      </div>
+    </div>
   );
 }

--- a/app/sources/page.tsx
+++ b/app/sources/page.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { createClient } from "@/lib/supabase";
+import styles from "./Sources.module.css";
 
 export const revalidate = 300;
 
@@ -13,9 +14,9 @@ export default async function SourcesPage() {
 
   const { data: profiles } = await supabase
     .from("source_ideology_scores")
-    .select("source_id, article_sample_count, identity_score, state_trust_score, economic_score, institution_score");
+    .select("source_id, article_sample_count");
 
-  const profileMap = new Map<string, any>();
+  const profileMap = new Map<string, { article_sample_count: number }>();
   for (const row of profiles ?? []) {
     profileMap.set(row.source_id, row);
   }
@@ -26,62 +27,58 @@ export default async function SourcesPage() {
   }));
 
   return (
-    <main className="max-w-5xl mx-auto px-4 py-10 space-y-8">
-      <header className="space-y-2">
-        <p className="text-xs uppercase tracking-[0.2em] text-neutral-500">NewsMirror</p>
-        <h1 className="text-2xl sm:text-3xl font-semibold tracking-tight">Sources & editorial profiles</h1>
-        <p className="text-sm text-neutral-500 max-w-xl">
-          We read each outlet over the last 90 days and infer a soft profile of how it frames identity, the state,
-          the economy, and institutions. No raw scores are shown here; only relative tendencies.
-        </p>
-      </header>
+    <div className={styles.page}>
+      <div className={styles.container}>
+        <header className={styles.header}>
+          <a href="/feed" className={styles.backLink}>
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+              <path d="M9 2L4 7l5 5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+            Back to feed
+          </a>
+          <h1 className={styles.title}>Sources &amp; editorial profiles</h1>
+          <p className={styles.subtitle}>
+            We read each outlet over the last 90 days and infer a soft profile of how it frames
+            identity, the state, the economy, and institutions. No raw scores are shown — only
+            relative tendencies.
+          </p>
+        </header>
 
-      <section className="grid gap-4 sm:grid-cols-2">
-        {enriched.map((source) => {
-          const p = source.profile;
-          const ready = p && p.article_sample_count >= 10;
-          return (
-            <a
-              key={source.id}
-              href={`/sources/${source.id}`}
-              className="group rounded-2xl border border-neutral-800 bg-neutral-950/60 px-4 py-4 flex flex-col gap-3 hover:border-neutral-700 hover:bg-neutral-900/70 transition-colors"
-            >
-              <div className="flex items-center justify-between gap-2">
-                <div className="space-y-0.5">
-                  <div className="text-sm font-medium tracking-tight text-white flex items-center gap-1.5">
-                    <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-neutral-900 text-[11px] font-semibold border border-neutral-700">
-                      {source.name.charAt(0).toUpperCase()}
-                    </span>
-                    <span>{source.name}</span>
+        <div className={styles.grid}>
+          {enriched.map((source) => {
+            const ready = source.profile && source.profile.article_sample_count >= 10;
+            return (
+              <a key={source.id} href={`/sources/${source.id}`} className={styles.card}>
+                <div className={styles.cardTop}>
+                  <div className={styles.avatar}>
+                    {source.name.charAt(0).toUpperCase()}
                   </div>
-                  <p className="text-[11px] uppercase tracking-[0.16em] text-neutral-500">
-                    {source.language.toUpperCase()} · {ready ? "Profile ready" : "Profile building"}
-                  </p>
+                  <div className={styles.cardMeta}>
+                    <span className={styles.cardName}>{source.name}</span>
+                    <span className={styles.cardStatus}>
+                      <span className={styles.langPill}>{source.language.toUpperCase()}</span>
+                      {ready ? (
+                        <span className={styles.statusReady}>Profile ready</span>
+                      ) : (
+                        <span className={styles.statusBuilding}>Profile building</span>
+                      )}
+                    </span>
+                  </div>
+                  <svg className={styles.chevron} width="14" height="14" viewBox="0 0 14 14" fill="none">
+                    <path d="M5 2l5 5-5 5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
                 </div>
-                {ready && (
-                  <div className="flex items-center gap-1 text-[11px] text-neutral-400">
-                    <span className="inline-flex h-1.5 w-10 overflow-hidden rounded-full bg-neutral-800">
-                      <span className="h-full w-1/2 bg-amber-400/80 group-hover:bg-amber-300/90 transition-colors" />
-                    </span>
-                    <span>View stance</span>
-                  </div>
-                )}
-              </div>
 
-              {ready ? (
-                <p className="text-xs text-neutral-400 leading-relaxed">
-                  Based on {p.article_sample_count} recent stories, this outlet shows a distinct editorial pattern across identity,
-                  the state, economy, and institutions.
+                <p className={styles.cardBody}>
+                  {ready
+                    ? `Based on ${source.profile!.article_sample_count} recent stories, this outlet has a distinct editorial pattern across identity, the state, economy, and institutions.`
+                    : "We\'re still reading this outlet. A profile appears once we have at least 10 representative articles."}
                 </p>
-              ) : (
-                <p className="text-xs text-neutral-500 leading-relaxed">
-                  We are still reading this outlet. A profile appears once we have at least 10 representative articles.
-                </p>
-              )}
-            </a>
-          );
-        })}
-      </section>
-    </main>
+              </a>
+            );
+          })}
+        </div>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Problem
The `/sources` and `/sources/[id]` pages introduced in PR #21 used Tailwind utility classes, but the app has no Tailwind pipeline — only CSS modules and CSS custom properties. This meant the pages rendered as completely unstyled raw text (no card grid, no avatar, no spacing, no fonts).

## Fix
Full rewrite of both page files and their CSS using CSS modules and the existing design system variables (`--bg`, `--surface`, `--surface-2`, `--border`, `--accent`, `--text-primary`, `--text-secondary`, `--text-tertiary`, `--r-lg`, `--r-sm`, `--font-display`, etc).

### New files
- `app/sources/Sources.module.css` — styles for the sources list page
- `app/sources/[id]/SourceProfile.module.css` — styles for the individual source profile page

### Changed files
- `app/sources/page.tsx` — replaces all utility class strings with CSS module imports
- `app/sources/[id]/page.tsx` — same; also extracts `AXES` and helper functions to the top of the file for clarity

## Visual design

### `/sources` list
- Full-height dark page matching the admin page layout (`var(--bg)`, max-width 680px, 1rem padding)
- Back-to-feed link
- `Playfair Display` h1 + subtitle in `--text-secondary`
- Each source renders as a card (`var(--surface)` + border, `--r-lg` radius, hover to `--surface-2`)
  - 32px circular avatar (initial letter)
  - Source name + `LANG` pill + `Profile ready` (green) or `Profile building` (tertiary) status
  - Body text indented to align with source name
  - Chevron icon on the right

### `/sources/[id]` profile
- Same page shell, same max-width
- Header: back link, 40px avatar, source name in display font, status row, "Visit" link in accent colour, intro paragraph
- **Axis cards** in a 2-column grid (1-column below 480px):
  - `IDENTITY FRAMING` label, strength value (`Neutral` / `Subtle tilt` / `Distinct tilt`) colour-coded
    - Neutral → `--text-secondary`
    - Subtle tilt → blue tint (`#9dcfff`)
    - Distinct tilt → `--accent` (saffron)
  - Small bar track (56px wide, 4px tall) with saffron fill whose width reflects deviation from neutral
  - Axis description in `--text-secondary`
- **Representative stories** (only if classifier_rationale is available):
  - Each story is a hoverable card: headline (2-line clamp), summary (3-line clamp), rationale grid below a thin border
  - 2-column rationale grid (1-column on mobile), each item with uppercased axis prefix
- **Methodology note** separated by a border at the bottom

## No logic changes
All data fetching, the `article_sample_count >= 10` readiness gate, and the axis key names are identical to PR #21.